### PR TITLE
Update Readme

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-custom: ['https://www.xtreme.net.cn/donate']
+custom: ['https://www.xtreme.net.cn/Donate']

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Portions of the materials contained herein are property of Innersloth LLC. © In
 
 # Source of ideas & Supports
  - [Town Of Host](https://github.com/tukasa0001/TownOfHost)
- - [Town Of Host Edited(Formerly Town Of Host Edited)](https://github.com/KARPED1EM/TownOfHostEdited)
+ - [Town Of Next(Formerly Town Of Host Edited)](https://github.com/KARPED1EM/TownOfNext)
  - [Town Of Host_Y](https://github.com/Yumenopai/TownOfHost_Y)
  - [Town Of Host:The Other Roles](https://github.com/music-discussion/TownOfHost-TheOtherRoles)
  - [Super New Roles](https://github.com/ykundesu/SuperNewRoles)


### PR DESCRIPTION
在English Readme中TONX的名称与仓库链接不正确。
尽管这不影响跳转至TONX的仓库,但一个模组更名不会更如名(`Town Of Host Edited(Formerly Town Of Host Edited)`)。